### PR TITLE
Fixed pods use_frameworks! missing bundle issue.

### DIFF
--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -43,12 +43,13 @@
 + (NSDictionary *)getDeviceList {
   NSDictionary *deviceList = nil;
   if (deviceList == nil) {
+    NSBundle *deviceUtilTopBundle = [NSBundle bundleForClass:[self class]];
     NSBundle *deviceUtilBundle = nil;
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"DeviceUtil" withExtension:@"bundle"];
+    NSURL *url = [deviceUtilTopBundle URLForResource:@"DeviceUtil" withExtension:@"bundle"];
     if (url == nil) {
       //the bundle is not present tyr main bundle, this will happen if you drag and drop the files
       //instead of using pod
-      deviceUtilBundle = [NSBundle mainBundle];
+      deviceUtilBundle = deviceUtilTopBundle;
     }
     else {
       //device bundle is present just load it
@@ -59,7 +60,6 @@
   }
   return deviceList;
 }
-
 
 + (Hardware)hardware {
   NSString *hardware = [self hardwareString];


### PR DESCRIPTION
Hi!
There is an issue with cocoapods and Podfile 'use_frameworks!' flag.
When used, each pod have its own top bundle (DeviceUtil.framework for example).
Because of this, the DeviceUtil.bundle can't be found inside [NSBundle mainBundle].

The plain substitution of: [NSBundle mainBundle] 
to something like: [NSBundle bundleForClass:[self class]]
(Or if preferred, it may be: [NSBundle bundleForClass:[DeviceUtll class]])
is fixing this issue, hopefully without breaking anything else.

It was checked, that in case 'use_frameworks!' not present, the [NSBundle bundleForClass:[self class]]
returns pointer to the same object as [NSBundle mainBundle].