### PR TITLE
Device support for iPad Pro 9.7

### DIFF
--- a/DeviceList.plist
+++ b/DeviceList.plist
@@ -366,6 +366,20 @@
 		<key>name</key>
 		<string>iPad Air 2 (Wi-Fi + Cellular)</string>
 	</dict>
+	<key>iPad6,3</key>
+	<dict>
+		<key>version</key>
+		<real>6.3</real>
+		<key>name</key>
+		<string>iPad Pro 9.7-inch (Wi-Fi Only)</string>
+	</dict>
+	<key>iPad6,4</key>
+	<dict>
+		<key>version</key>
+		<real>6.4</real>
+		<key>name</key>
+		<string>iPad Pro 9.7-inch (Wi-Fi + Cellular)</string>
+	</dict>
 	<key>iPad6,7</key>
 	<dict>
 		<key>version</key>

--- a/DeviceUtil.h
+++ b/DeviceUtil.h
@@ -68,7 +68,10 @@ typedef NS_ENUM(NSUInteger, Hardware) {
   IPAD_AIR_WIFI_CDMA,
   IPAD_AIR_2_WIFI,
   IPAD_AIR_2_WIFI_CELLULAR,
-  
+
+  IPAD_PRO_97_WIFI,
+  IPAD_PRO_97_WIFI_CELLULAR,
+
   IPAD_PRO_WIFI,
   IPAD_PRO_WIFI_CELLULAR,
 
@@ -133,6 +136,8 @@ static NSString* const iPad5_1 = @"iPad5,1";
 static NSString* const iPad5_2 = @"iPad5,2";
 static NSString* const iPad5_3 = @"iPad5,3";
 static NSString* const iPad5_4 = @"iPad5,4";
+static NSString* const iPad6_3 = @"iPad6,3";
+static NSString* const iPad6_4 = @"iPad6,4";
 static NSString* const iPad6_7 = @"iPad6,7";
 static NSString* const iPad6_8 = @"iPad6,8";
 

--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -119,7 +119,10 @@
   
   if ([hardware isEqualToString:iPad5_3])      return IPAD_AIR_2_WIFI;
   if ([hardware isEqualToString:iPad5_4])      return IPAD_AIR_2_WIFI_CELLULAR;
-  
+
+  if ([hardware isEqualToString:iPad6_3])      return IPAD_PRO_97_WIFI;
+  if ([hardware isEqualToString:iPad6_4])      return IPAD_PRO_97_WIFI_CELLULAR;
+
   if ([hardware isEqualToString:iPad6_7])      return IPAD_PRO_WIFI;
   if ([hardware isEqualToString:iPad6_8])      return IPAD_PRO_WIFI_CELLULAR;
   

--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -223,6 +223,11 @@
     case IPAD_AIR_2_WIFI_CELLULAR:
       return CGSizeMake (1536, 2048);
       break;
+
+    case IPAD_PRO_97_WIFI:
+    case IPAD_PRO_97_WIFI_CELLULAR:
+      return CGSizeMake(4032, 3024);
+      break;
       
     default:
       NSLog(@"We have no resolution for your device's camera listed in this category. Please, make photo with back camera of your device, get its resolution in pixels (via Preview Cmd+I for example) and add a comment to this repository (https://github.com/InderKumarRathore/DeviceUtil) on GitHub.com in format Device = Hpx x Wpx.");


### PR DESCRIPTION
Used strings IPAD_PRO_97_WIFI and IPAD_PRO_97_WIFI_CELLULAR for identifiers. Feel free to suggest something better and I'll update the PR.