### PR TITLE
 - add HARDWARE_MAX to the Hardware enum, to reliably count the numbe…

### DIFF
--- a/DeviceUtil.h
+++ b/DeviceUtil.h
@@ -75,7 +75,9 @@ typedef NS_ENUM(NSUInteger, Hardware) {
   IPAD_PRO_WIFI,
   IPAD_PRO_WIFI_CELLULAR,
 
-  SIMULATOR
+  SIMULATOR,
+
+  HARDWARE_MAX
 };
 
 /**


### PR DESCRIPTION
 - add HARDWARE_MAX to the Hardware enum, to reliably count the number of elements in the enum (used to ensure client code handles every device type properly, if they want to)

our use case:
```cpp
std::map<Hardware, /*some other type*/> hardwareToOther{...};
assert(hardwareToOther.size() == Hardware::HARDWARE_MAX);
```