### PR TITLE
Reintroduction of hardwareSimpleDescription method in DeviceUtil class

### DIFF
--- a/DeviceUtil.h
+++ b/DeviceUtil.h
@@ -158,6 +158,9 @@ static NSString* const x86_64_Sim  = @"x86_64";
 /** This method returns the readable description of hardware string */
 + (NSString*)hardwareDescription;
 
+/** This method returns the readable simple description of hardware string */
++ (NSString*)hardwareSimpleDescription;
+
 /**
  This method returns the hardware number not actual but logically.
  e.g. if the hardware string is 5,1 then hardware number would be 5.1

--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -150,6 +150,21 @@
   }
 }
 
++ (NSString*)hardwareSimpleDescription {
+  NSString *hardwareDescription = [DeviceUtil hardwareDescription];
+  if (hardwareDescription == nil) {
+    return nil;
+  }
+  NSError *error = nil;
+  // this expression matches all strings between round brackets (e.g (Wifi), (GSM)) except the pattern "[0-9]+ Gen"
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\((?![0-9]+ Gen).*\\)" options:NSRegularExpressionCaseInsensitive error:&error];
+  NSString *hardwareSimpleDescription = [regex stringByReplacingMatchesInString:hardwareDescription options:0 range:NSMakeRange(0, [hardwareDescription length]) withTemplate:@""];
+  if (error) {
+    return nil;
+  } else {
+    return hardwareSimpleDescription;
+  }
+}
 
 + (float)hardwareNumber {
   NSString *hardware = [self hardwareString];


### PR DESCRIPTION
I have created a new version of hardwareSimpleDescription method. It is useful to return a simpler description of an Apple device. For example it returns:
- iPad 2 rather than iPad 2 (GSM)
- iPhone 5s rather than iPhone 5s (Global)
  It is based on regular expression useful to delete all strings in round brackets (e.g. "(GSM)") except for patterns like "(1 Gen)" used in iPod device description.

This PR resolves the issue #47 
