### PR TITLE
Platform method that tell whether the device is iphone/ipodtouch/ipad/watch or appletv should be public.

### DIFF
--- a/DeviceUtil.h
+++ b/DeviceUtil.h
@@ -255,6 +255,13 @@ extern NSString* const x86_64_Sim;
  */
 - (float)hardwareNumber;
 
+/// This method returns the Platform enum depending upon harware string
+///
+///
+/// - returns: `Platform` type of the device
+///
+- (Platform)platform;
+
 /** This method returns the resolution for still image that can be received
  from back camera of the current device. Resolution returned for image oriented landscape right. **/
 - (CGSize)backCameraStillImageResolutionInPixels;

--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -173,11 +173,6 @@ NSString* const x86_64_Sim  = @"x86_64";
  */
 
 
-/// This method returns the Platform enum depending upon harware string
-///
-///
-/// - returns: `Platform` type of the device
-///
 - (Platform)platform {
   
   NSString *hardware = [self hardwareString];


### PR DESCRIPTION
The platform was added but couldn't be used from another class.
The method was added to the interface declaration.